### PR TITLE
3Dガウシアン・スプラッティング（3DGS）のデータを背景として使えるようにする

### DIFF
--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.Contracts/SpatialEnvironment/Constants.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.Contracts/SpatialEnvironment/Constants.cs
@@ -2,6 +2,7 @@ namespace Kinemagic.Apps.Studio.Contracts.SpatialEnvironment
 {
     public static class Constants
     {
+        public const string RenderingLayerName = "Environment";
         public const string PersistentDataDirectoryName = "EnvironmentModels";
     }
 }

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentLightingManager.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentLightingManager.cs
@@ -1,0 +1,274 @@
+using System;
+using Unity.Mathematics;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
+{
+    [ExecuteAlways]
+    [RequireComponent(typeof(Camera))]
+    public sealed class EnvironmentLightingManager : MonoBehaviour
+    {
+        public const string SkyboxShaderName = "Skybox/Cubemap";
+        public readonly int SkyboxTexId = Shader.PropertyToID("_Tex");
+
+        [SerializeField] private CubemapSizeType _cubemapSize = CubemapSizeType.W1024xH1024;
+        [SerializeField] private LayerMask _renderingLayerMask = 1; // 1: Default layer
+
+        private readonly CubemapFace[] _cubemapFaces =
+        {
+            CubemapFace.PositiveZ,
+            CubemapFace.NegativeZ,
+            CubemapFace.PositiveY,
+            CubemapFace.NegativeY,
+            CubemapFace.PositiveX,
+            CubemapFace.NegativeX
+        };
+
+        private bool _initialized;
+        private Camera _renderCamera;
+        private RenderTexture _cubemapRenderTexture;
+        private Material _skyboxMaterial;
+
+        private AmbientMode _previousAmbientMode;
+        private Material _previousSkyboxMaterial;
+        private DefaultReflectionMode _previousReflectionMode;
+        private Texture _previousCustomReflection;
+        private float _previousReflectionIntensity;
+
+        #region MonoBehaviour Functions
+
+        void Awake()
+        {
+            _renderCamera = GetComponent<Camera>();
+        }
+
+        void OnEnable()
+        {
+            _renderCamera.enabled = false;
+            _renderCamera.cullingMask = _renderingLayerMask;
+        }
+
+        void OnDestroy()
+        {
+            Dispose();
+        }
+
+        #endregion
+
+        public void Dispose()
+        {
+            if (_skyboxMaterial != null)
+            {
+                DestroyUnityObject(_skyboxMaterial);
+            }
+
+            if (_cubemapRenderTexture != null)
+            {
+                _cubemapRenderTexture.Release();
+                DestroyUnityObject(_cubemapRenderTexture);
+            }
+
+            // Restore previous settings
+            RenderSettings.ambientMode = _previousAmbientMode;
+            RenderSettings.skybox = _previousSkyboxMaterial;
+            RenderSettings.defaultReflectionMode = _previousReflectionMode;
+            RenderSettings.customReflectionTexture = _previousCustomReflection;
+            RenderSettings.reflectionIntensity = _previousReflectionIntensity;
+
+            _initialized = false;
+        }
+
+        public void Initialize()
+        {
+            if (_initialized) return;
+
+            _skyboxMaterial = new Material(Shader.Find(SkyboxShaderName));
+
+            var (width, height) = _cubemapSize.GetDimensions();
+            CreateCubemapRenderTexture(width, height);
+
+            // Store previous settings
+            _previousAmbientMode = RenderSettings.ambientMode;
+            _previousSkyboxMaterial = RenderSettings.skybox;
+            _previousReflectionMode = RenderSettings.defaultReflectionMode;
+            _previousCustomReflection = RenderSettings.customReflectionTexture;
+            _previousReflectionIntensity = RenderSettings.reflectionIntensity;
+
+            _initialized = true;
+        }
+
+        /// <summary>
+        /// Update environment lighting by rendering the scene to a cubemap.
+        /// </summary>
+        public void UpdateEnvironmentLightingFromScene()
+        {
+            if (!_initialized)
+            {
+                Initialize();
+            }
+
+            var (width, height) = _cubemapSize.GetDimensions();
+            if (_cubemapRenderTexture?.width != width || _cubemapRenderTexture?.height != height)
+            {
+                CreateCubemapRenderTexture(width, height);
+            }
+
+            RenderToCubemap();
+            UpdateReflections();
+            UpdateAmbientLighting();
+        }
+
+        private void CreateCubemapRenderTexture(int width, int height)
+        {
+            if (_cubemapRenderTexture != null)
+            {
+                _cubemapRenderTexture.Release();
+                DestroyUnityObject(_cubemapRenderTexture);
+            }
+
+            _cubemapRenderTexture = new RenderTexture(width, height, depth: 24, RenderTextureFormat.ARGBFloat);
+            _cubemapRenderTexture.dimension = TextureDimension.Cube;
+            _cubemapRenderTexture.useMipMap = true;
+            _cubemapRenderTexture.autoGenerateMips = false;
+            _cubemapRenderTexture.Create();
+        }
+
+        private void RenderToCubemap()
+        {
+            var renderRequest = new UniversalRenderPipeline.SingleCameraRequest();
+            renderRequest.destination = _cubemapRenderTexture;
+
+            // Check if the active render pipeline supports the render request
+            if (!RenderPipeline.SupportsRenderRequest(_renderCamera, renderRequest))
+            {
+                Debug.LogError("The current render pipeline does not support single camera render requests.");
+                return;
+            }
+
+            // These must be set before calling ResetProjectionMatrix.
+            // これらはResetProjectionMatrixを呼び出す前に設定する必要があります。
+            _renderCamera.fieldOfView = 90f;
+            _renderCamera.targetTexture = _cubemapRenderTexture;
+
+            // Modify the projection matrix to prevent the cubemap from inverting vertically.
+            // Cubemapが上下反転しないようにプロジェクション行列を変更する。
+            _renderCamera.ResetProjectionMatrix();
+            var newProjection = math.mul(
+                new float4x4(
+                    1, 0, 0, 0,
+                    0, -1, 0, 0,
+                    0, 0, 1, 0,
+                    0, 0, 0, 1
+                ),
+                _renderCamera.projectionMatrix
+            );
+            _renderCamera.projectionMatrix = newProjection;
+
+            // Render cubemap faces
+            foreach (var cubemapFace in _cubemapFaces)
+            {
+                _renderCamera.cullingMask = _renderingLayerMask;
+                _renderCamera.transform.rotation = cubemapFace switch
+                {
+                    CubemapFace.PositiveZ => Quaternion.Euler(0, 0, 0),
+                    CubemapFace.NegativeZ => Quaternion.Euler(0, 180, 0),
+                    CubemapFace.PositiveY => Quaternion.Euler(-90, 0, 0),
+                    CubemapFace.NegativeY => Quaternion.Euler(90, 0, 0),
+                    CubemapFace.PositiveX => Quaternion.Euler(0, 90, 0),
+                    CubemapFace.NegativeX => Quaternion.Euler(0, -90, 0),
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+                renderRequest.face = cubemapFace;
+                RenderPipeline.SubmitRenderRequest(_renderCamera, renderRequest);
+            }
+
+            _cubemapRenderTexture.GenerateMips();
+        }
+
+        private void UpdateAmbientLighting()
+        {
+            _skyboxMaterial.SetTexture(SkyboxTexId, _cubemapRenderTexture);
+
+            RenderSettings.ambientMode = AmbientMode.Skybox;
+            RenderSettings.skybox = _skyboxMaterial;
+
+            DynamicGI.UpdateEnvironment();
+        }
+
+        private void UpdateReflections()
+        {
+            RenderSettings.defaultReflectionMode = DefaultReflectionMode.Custom;
+            RenderSettings.customReflectionTexture = _cubemapRenderTexture;
+            RenderSettings.reflectionIntensity = 1.0f;
+        }
+
+        private static void DestroyUnityObject(UnityEngine.Object o)
+        {
+            if (Application.isPlaying)
+            {
+                UnityEngine.Object.Destroy(o);
+            }
+            else
+            {
+                UnityEngine.Object.DestroyImmediate(o);
+            }
+        }
+    }
+
+    public enum CubemapSizeType
+    {
+        W256xH256,
+        W512xH512,
+        W1024xH1024,
+        W2048xH2048,
+        W4096xH4096,
+    }
+
+    public static class CubemapSizeTypeExtensions
+    {
+        public static (int, int) GetDimensions(this CubemapSizeType sizeType)
+        {
+            return sizeType switch
+            {
+                CubemapSizeType.W256xH256 => (256, 256),
+                CubemapSizeType.W512xH512 => (512, 512),
+                CubemapSizeType.W1024xH1024 => (1024, 1024),
+                CubemapSizeType.W2048xH2048 => (2048, 2048),
+                CubemapSizeType.W4096xH4096 => (4096, 4096),
+                _ => throw new ArgumentOutOfRangeException(nameof(sizeType), sizeType, null)
+            };
+        }
+    }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(EnvironmentLightingManager))]
+    public sealed class EnvironmentLightingManagerEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            var manager = target as EnvironmentLightingManager;
+            if (manager == null) return;
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Environment Lighting Controls", EditorStyles.boldLabel);
+
+            if (GUILayout.Button("Update Environment Lighting From Scene"))
+            {
+                manager.UpdateEnvironmentLightingFromScene();
+            }
+
+            if (GUILayout.Button("Reset"))
+            {
+                manager.Dispose();
+            }
+        }
+    }
+#endif
+}

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentLightingManager.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentLightingManager.cs
@@ -40,6 +40,11 @@ namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
         private Texture _previousCustomReflection;
         private float _previousReflectionIntensity;
 
+        public LayerMask RenderingLayerMask
+        {
+            set => _renderingLayerMask = value;
+        }
+
         #region MonoBehaviour Functions
 
         void Awake()
@@ -50,7 +55,6 @@ namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
         void OnEnable()
         {
             _renderCamera.enabled = false;
-            _renderCamera.cullingMask = _renderingLayerMask;
         }
 
         void OnDestroy()

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentLightingManager.cs.meta
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentLightingManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed05f16e3737d4ec28cd1ee60208211a

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentSystem.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/EnvironmentSystem.cs
@@ -47,7 +47,10 @@ namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
 
         public async UniTask InitializeAsync()
         {
-            await StreamingAssetsSynchronizer.SynchronizeFilesAsync(Constants.PersistentDataDirectoryName, "*.glb", _cancellationTokenSource.Token);
+            await UniTask.WhenAll(
+                StreamingAssetsSynchronizer.SynchronizeFilesAsync(Constants.PersistentDataDirectoryName, "*.glb", _cancellationTokenSource.Token),
+                StreamingAssetsSynchronizer.SynchronizeFilesAsync(Constants.PersistentDataDirectoryName, "*.spz", _cancellationTokenSource.Token)
+            );
 
             _currentScene = SpatialEnvironmentScene.CreateDefault();
 

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/CompositeEnvironmentSceneProvider.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/CompositeEnvironmentSceneProvider.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Kinemagic.Apps.Studio.Contracts.SpatialEnvironment;
+using UnityEngine;
+
+namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
+{
+    public sealed class CompositeEnvironmentSceneProvider : IEnvironmentSceneProvider
+    {
+        private readonly GlbImporter _glbImporter;
+        private readonly GaussianSplatSceneImporter _gaussianSplatImporter;
+
+        public CompositeEnvironmentSceneProvider(
+            GlbImporter glbImporter,
+            GaussianSplatSceneImporter gaussianSplatImporter)
+        {
+            _glbImporter = glbImporter ?? throw new ArgumentNullException(nameof(glbImporter));
+            _gaussianSplatImporter = gaussianSplatImporter ?? throw new ArgumentNullException(nameof(gaussianSplatImporter));
+        }
+
+        public async UniTask<SpatialEnvironmentScene> LoadAsync(string key, BinaryDataStorageType storageType,
+            CancellationToken cancellationToken = default)
+        {
+            var provider = SelectProvider(key);
+            if (provider == null)
+            {
+                Debug.LogError($"Unsupported file format: {key}");
+                return null;
+            }
+
+            return await provider.LoadAsync(key, storageType, cancellationToken);
+        }
+
+        private IEnvironmentSceneProvider SelectProvider(string filePath)
+        {
+            var extension = Path.GetExtension(filePath).ToLowerInvariant();
+
+            return extension switch
+            {
+                ".glb" => _glbImporter,
+                ".spz" => _gaussianSplatImporter,
+                _ => null
+            };
+        }
+    }
+}

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/CompositeEnvironmentSceneProvider.cs.meta
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/CompositeEnvironmentSceneProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92cd0a36ab54640a087c615beeb14143

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneConfig.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneConfig.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
+{
+    [CreateAssetMenu(fileName = "GaussianSplatSceneConfig", menuName = "Kinemagic/GaussianSplatSceneConfig")]
+    public sealed class GaussianSplatSceneConfig : ScriptableObject
+    {
+        public Shader SplatsShader;
+        public Shader CompositeShader;
+        public Shader DebugPointsShader;
+        public Shader DebugBoxesShader;
+        public ComputeShader SplatUtilitiesComputeShader;
+    }
+}

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneConfig.cs.meta
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 607694499012a4262903b03fe916f591

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneImporter.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneImporter.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using GaussianSplatting.Runtime;
+using Kinemagic.Apps.Studio.Contracts.SpatialEnvironment;
+using UnityEngine;
+
+namespace Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment
+{
+    public sealed class GaussianSplatSceneImporter : IEnvironmentSceneProvider
+    {
+        private readonly GaussianSplatSceneConfig _config;
+        private readonly IBinaryDataStorage _binaryDataStorage;
+        private readonly GaussianSplatImporter _gaussianSplatImporter;
+
+        public GaussianSplatSceneImporter(GaussianSplatSceneConfig config, IBinaryDataStorage binaryDataStorage)
+        {
+            _config = config;
+            _binaryDataStorage = binaryDataStorage;
+            _gaussianSplatImporter = new(GaussianSplatImporter.DataQuality.Medium);
+        }
+
+        public async UniTask<SpatialEnvironmentScene> LoadAsync(string key, BinaryDataStorageType storageType,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var bytes = await _binaryDataStorage.LoadAsync(key, storageType, cancellationToken);
+                if (bytes == null || bytes.Length == 0)
+                {
+                    return null;
+                }
+
+                var name = Path.GetFileNameWithoutExtension(key);
+                var splatAsset = _gaussianSplatImporter.Load(bytes, name);
+                if (splatAsset == null)
+                {
+                    Debug.LogError($"Failed to import Gaussian Splat data from {key}");
+                    return null;
+                }
+
+                // Create a new GameObject to render the splat
+                var rootObject = new GameObject($"GaussianSplat_{name}");
+                var renderer = rootObject.AddComponent<GaussianSplatRenderer>();
+
+                // Assign the loaded asset
+                renderer.m_Asset = splatAsset;
+
+                // Assign shaders if provided
+                renderer.m_ShaderSplats = _config.SplatsShader;
+                renderer.m_ShaderComposite = _config.CompositeShader;
+                renderer.m_ShaderDebugPoints = _config.DebugPointsShader;
+                renderer.m_ShaderDebugBoxes = _config.DebugBoxesShader;
+                renderer.m_CSSplatUtilities = _config.SplatUtilitiesComputeShader;
+
+                // Apply display settings
+                renderer.m_SplatScale = 1.0f;
+                renderer.m_OpacityScale = 1.0f;
+                renderer.m_SHOrder = 3;
+
+                // Force enable to trigger resource creation
+                renderer.enabled = false;
+                renderer.enabled = true;
+
+                return new SpatialEnvironmentScene(rootObject);
+            }
+            catch (OperationCanceledException)
+            {
+                Debug.Log($"Loading Gaussian Splat was canceled.");
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                return null;
+            }
+        }
+    }
+}

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneImporter.cs.meta
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/GaussianSplatSceneImporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2c2a366497fa4cadb3de142c5fd0882

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment.Infrastructure.asmdef
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Infrastructure/Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment.Infrastructure.asmdef
@@ -5,7 +5,8 @@
         "Kinemagic.Apps.Studio.Contracts",
         "Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment",
         "UniTask",
-        "glTFast"
+        "glTFast",
+        "GaussianSplatting"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment.asmdef
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio.FeatureCore/SpatialEnvironment/Kinemagic.Apps.Studio.FeatureCore.SpatialEnvironment.asmdef
@@ -5,7 +5,9 @@
         "Kinemagic.Apps.Studio.Contracts",
         "EngineLooper.Annotations",
         "UniTask",
-        "MessagePipe"
+        "MessagePipe",
+        "Unity.Mathematics",
+        "Unity.RenderPipelines.Universal.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scenes/Stage.unity
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scenes/Stage.unity
@@ -190,7 +190,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 296948212}
-  m_Mesh: {fileID: 867720515}
+  m_Mesh: {fileID: 921732827}
 --- !u!114 &296948215
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,7 +283,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 296948216}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &867720515
+--- !u!43 &921732827
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -448,6 +448,151 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1 &1030710257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1030710261}
+  - component: {fileID: 1030710260}
+  - component: {fileID: 1030710259}
+  - component: {fileID: 1030710258}
+  m_Layer: 0
+  m_Name: EnvironmentLightingManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1030710258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030710257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!20 &1030710259
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030710257}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &1030710260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030710257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed05f16e3737d4ec28cd1ee60208211a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _cubemapSize: 2
+  _renderingLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+--- !u!4 &1030710261
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1030710257}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1351823941
 GameObject:
   m_ObjectHideFlags: 0
@@ -498,6 +643,7 @@ MonoBehaviour:
   autoInjectGameObjects: []
   _spatialCoordinateProvider: {fileID: 1850792704}
   _gaussianSplatSceneConfig: {fileID: 11400000, guid: 8262fbb3f6031437a91d0064a831c32b, type: 2}
+  _environmentLightingManager: {fileID: 1030710260}
 --- !u!1 &1850792703
 GameObject:
   m_ObjectHideFlags: 0
@@ -550,3 +696,4 @@ SceneRoots:
   - {fileID: 1351823942}
   - {fileID: 296948216}
   - {fileID: 1850792705}
+  - {fileID: 1030710261}

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scenes/Stage.unity
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scenes/Stage.unity
@@ -497,6 +497,7 @@ MonoBehaviour:
   autoRun: 1
   autoInjectGameObjects: []
   _spatialCoordinateProvider: {fileID: 1850792704}
+  _gaussianSplatSceneConfig: {fileID: 11400000, guid: 8262fbb3f6031437a91d0064a831c32b, type: 2}
 --- !u!1 &1850792703
 GameObject:
   m_ObjectHideFlags: 0

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scripts/Lifecycle/StageLifetimeScope.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scripts/Lifecycle/StageLifetimeScope.cs
@@ -12,6 +12,9 @@ namespace Kinemagic.Apps.Studio.Lifecycle
         [Header("Character System")]
         [SerializeField] SpatialCoordinateProvider _spatialCoordinateProvider;
 
+        [Header("Environment System")]
+        [SerializeField] GaussianSplatSceneConfig _gaussianSplatSceneConfig;
+
         protected override void Configure(IContainerBuilder builder)
         {
             ConfigureCharacterSystem(builder);
@@ -44,7 +47,10 @@ namespace Kinemagic.Apps.Studio.Lifecycle
 
             builder.Register<EnvironmentModelInfoLocalRepository>(Lifetime.Singleton).AsImplementedInterfaces();
 
-            builder.Register<GlbImporter>(Lifetime.Singleton).AsImplementedInterfaces();
+            builder.Register<CompositeEnvironmentSceneProvider>(Lifetime.Singleton).AsImplementedInterfaces();
+            builder.Register<GlbImporter>(Lifetime.Singleton).AsSelf();
+            builder.Register<GaussianSplatSceneImporter>(Lifetime.Singleton).WithParameter(_gaussianSplatSceneConfig).AsSelf();
+
             builder.Register<FeatureCore.SpatialEnvironment.LocalFileBinaryDataStorage>(Lifetime.Singleton).AsImplementedInterfaces();
         }
     }

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scripts/Lifecycle/StageLifetimeScope.cs
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Scripts/Lifecycle/StageLifetimeScope.cs
@@ -14,6 +14,7 @@ namespace Kinemagic.Apps.Studio.Lifecycle
 
         [Header("Environment System")]
         [SerializeField] GaussianSplatSceneConfig _gaussianSplatSceneConfig;
+        [SerializeField] EnvironmentLightingManager _environmentLightingManager;
 
         protected override void Configure(IContainerBuilder builder)
         {
@@ -50,6 +51,8 @@ namespace Kinemagic.Apps.Studio.Lifecycle
             builder.Register<CompositeEnvironmentSceneProvider>(Lifetime.Singleton).AsImplementedInterfaces();
             builder.Register<GlbImporter>(Lifetime.Singleton).AsSelf();
             builder.Register<GaussianSplatSceneImporter>(Lifetime.Singleton).WithParameter(_gaussianSplatSceneConfig).AsSelf();
+
+            builder.RegisterInstance(_environmentLightingManager).AsSelf();
 
             builder.Register<FeatureCore.SpatialEnvironment.LocalFileBinaryDataStorage>(Lifetime.Singleton).AsImplementedInterfaces();
         }

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Settings/GaussianSplatSceneConfig.asset
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Settings/GaussianSplatSceneConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 607694499012a4262903b03fe916f591, type: 3}
+  m_Name: GaussianSplatSceneConfig
+  m_EditorClassIdentifier: 
+  SplatsShader: {fileID: 4800000, guid: ed800126ae8844a67aad1974ddddd59c, type: 3}
+  CompositeShader: {fileID: 4800000, guid: 7e184af7d01193a408eb916d8acafff9, type: 3}
+  DebugPointsShader: {fileID: 4800000, guid: b44409fc67214394f8f47e4e2648425e, type: 3}
+  DebugBoxesShader: {fileID: 4800000, guid: 4006f2680fd7c8b4cbcb881454c782be, type: 3}
+  SplatUtilitiesComputeShader: {fileID: 7200000, guid: ec84f78b836bd4f96a105d6b804f08bd, type: 3}

--- a/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Settings/GaussianSplatSceneConfig.asset.meta
+++ b/src/Apps/KinemagicStudio-CE/Assets/Kinemagic/Apps.Studio/Settings/GaussianSplatSceneConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8262fbb3f6031437a91d0064a831c32b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Apps/KinemagicStudio-CE/Assets/Settings/PC_Renderer.asset
+++ b/src/Apps/KinemagicStudio-CE/Assets/Settings/PC_Renderer.asset
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6301748324124746123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01052c1a4da12064d8681d7c1800f94a, type: 3}
+  m_Name: GaussianSplatURPFeature
+  m_EditorClassIdentifier: 
+  m_Active: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -27,7 +40,8 @@ MonoBehaviour:
   m_RendererFeatures:
   - {fileID: 7833122117494664109}
   - {fileID: 1209553651987089826}
-  m_RendererFeatureMap: ad6b866f10d7b46ca2897753a332c910
+  - {fileID: -6301748324124746123}
+  m_RendererFeatureMap: ad6b866f10d7b46ca2897753a332c910759ea18c49b18ba8
   m_UseNativeRenderPass: 1
   xrSystemData: {fileID: 0}
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}

--- a/src/Apps/KinemagicStudio-CE/Packages/manifest.json
+++ b/src/Apps/KinemagicStudio-CE/Packages/manifest.json
@@ -7,6 +7,7 @@
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.3.0",
     "com.hecomi.uosc": "https://github.com/hecomi/uOSC.git?path=Assets/uOSC#v2.2.0",
     "com.kinemagicstudio.appcore.utils": "file:../../Shared/Kinemagic.AppCore.Utils",
+    "org.nesnausk.gaussian-splatting": "https://github.com/sotanmochi/UnityGaussianSplatting.git?path=package#runtime-importer",
     "com.unity.ai.navigation": "2.0.9",
     "com.unity.cinemachine": "3.1.4",
     "com.unity.collab-proxy": "2.9.3",

--- a/src/Apps/KinemagicStudio-CE/Packages/manifest.json
+++ b/src/Apps/KinemagicStudio-CE/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.3.0",
     "com.hecomi.uosc": "https://github.com/hecomi/uOSC.git?path=Assets/uOSC#v2.2.0",
     "com.kinemagicstudio.appcore.utils": "file:../../Shared/Kinemagic.AppCore.Utils",
-    "org.nesnausk.gaussian-splatting": "https://github.com/sotanmochi/UnityGaussianSplatting.git?path=package#runtime-importer",
+    "org.nesnausk.gaussian-splatting": "https://github.com/sotanmochi/UnityGaussianSplatting.git?path=package#develop",
     "com.unity.ai.navigation": "2.0.9",
     "com.unity.cinemachine": "3.1.4",
     "com.unity.collab-proxy": "2.9.3",

--- a/src/Apps/KinemagicStudio-CE/Packages/packages-lock.json
+++ b/src/Apps/KinemagicStudio-CE/Packages/packages-lock.json
@@ -371,7 +371,7 @@
       "hash": "43d717453dcb50d7c881b8616e1b80b489208122"
     },
     "org.nesnausk.gaussian-splatting": {
-      "version": "https://github.com/sotanmochi/UnityGaussianSplatting.git?path=package#runtime-importer",
+      "version": "https://github.com/sotanmochi/UnityGaussianSplatting.git?path=package#develop",
       "depth": 0,
       "source": "git",
       "dependencies": {
@@ -379,7 +379,7 @@
         "com.unity.collections": "2.1.4",
         "com.unity.mathematics": "1.2.6"
       },
-      "hash": "58c83be455276336b0cc35d6029370290d2ca0f9"
+      "hash": "8816c1a4c78dcd00e392fd0473d27196b5dc7793"
     },
     "studio.shortsleeve.contextualmenuplayer": {
       "version": "https://github.com/sotanmochi/ContextualMenuPlayer.git?path=Assets/ContextualMenuPlayer#0.1.0",

--- a/src/Apps/KinemagicStudio-CE/Packages/packages-lock.json
+++ b/src/Apps/KinemagicStudio-CE/Packages/packages-lock.json
@@ -61,7 +61,7 @@
     },
     "com.unity.burst": {
       "version": "1.8.24",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
@@ -88,7 +88,7 @@
     },
     "com.unity.collections": {
       "version": "2.5.1",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.burst": "1.8.17",
@@ -145,7 +145,7 @@
     },
     "com.unity.mathematics": {
       "version": "1.3.2",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -160,7 +160,7 @@
     },
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.4",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -261,7 +261,7 @@
     },
     "com.unity.test-framework.performance": {
       "version": "3.1.0",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.test-framework": "1.1.33",
@@ -369,6 +369,17 @@
       "source": "git",
       "dependencies": {},
       "hash": "43d717453dcb50d7c881b8616e1b80b489208122"
+    },
+    "org.nesnausk.gaussian-splatting": {
+      "version": "https://github.com/sotanmochi/UnityGaussianSplatting.git?path=package#runtime-importer",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.burst": "1.8.8",
+        "com.unity.collections": "2.1.4",
+        "com.unity.mathematics": "1.2.6"
+      },
+      "hash": "58c83be455276336b0cc35d6029370290d2ca0f9"
     },
     "studio.shortsleeve.contextualmenuplayer": {
       "version": "https://github.com/sotanmochi/ContextualMenuPlayer.git?path=Assets/ContextualMenuPlayer#0.1.0",

--- a/src/Apps/KinemagicStudio-CE/ProjectSettings/QualitySettings.asset
+++ b/src/Apps/KinemagicStudio-CE/ProjectSettings/QualitySettings.asset
@@ -78,7 +78,7 @@ QualitySettings:
     antiAliasing: 0
     softParticles: 0
     softVegetation: 1
-    realtimeReflectionProbes: 0
+    realtimeReflectionProbes: 1
     billboardsFaceCameraPosition: 1
     useLegacyDetailDistribution: 1
     adaptiveVsync: 0

--- a/src/Apps/KinemagicStudio-CE/ProjectSettings/TagManager.asset
+++ b/src/Apps/KinemagicStudio-CE/ProjectSettings/TagManager.asset
@@ -13,7 +13,7 @@ TagManager:
   - UI
   - 
   - 
-  - 
+  - Environment
   - 
   - 
   - 


### PR DESCRIPTION
## 概要
<!-- 何を変更したのか。なぜ変更したのか。 -->
3Dガウシアン・スプラッティング（3DGS）のデータを背景として使えるようにする。
- 3DGSのデータ（.spzファイル）をランタイムで読み込める
- 3DGSオブジェクトが描画される
- 環境光の設定が更新される

<img width="2555" height="1415" alt="KinemagicStudio-CE_3DGS_2025-12-21" src="https://github.com/user-attachments/assets/923d1e7e-c066-4587-bd83-a637fb1c193b" />

## 関連情報
<!-- 関連するイシュー・プルリクエスト・ドキュメントなど。（ない場合は「なし」でOK） -->
なし

## 変更内容
### 主な変更点
- パッケージマネージャーを使って[UnityGaussianSplatting](https://github.com/sotanmochi/UnityGaussianSplatting)を追加した
- `GaussianSplatSceneConfig`クラスを追加した
- `GaussianSplatSceneImporter`クラスを追加した
- `EnvironmentLightingManager`クラスを追加した

### 変更したScene / Prefab / Settings
<!-- コンフリクト防止のために明記する。（ない場合は「なし」でOK） -->
- `PC_Renderer`に`GaussianSplatURPFeature`を追加した
- 環境光
  - 実行時に環境光を更新できるようにするため、`Quality Settings` の`Realtime Reflection Probes`を有効にした。
  - キューブマップにレンダリングする時に背景以外のオブジェクト（キャラクターなど）が描画されないようにするため、`Environment`というレイヤーを新規追加した。
- `Stage`シーン
  - `EnvironmentLightingManager`オブジェクトを追加した
  - `StageLifetimeScope`のシリアライズフィールドに`GaussianSplatSceneConfig`と`EnvironmentLightingManager`の参照を追加した

## 動作確認
### 環境
- [x] Unity Editor (Version: 6000.0.58f2)
- [ ] Windows ビルド
- [ ] MacOS ビルド

### 確認したこと
- [x] 3DGSのデータ（.spzファイル）がEnvironment Modelsの一覧に表示されること
- [x] 3DGSのサンプルデータ（ https://github.com/nianticlabs/spz/tree/main/samples ）を読み込めること
- [x] 3DGSオブジェクトが描画されていること
- [x] 環境光が更新されていること

<img width="2555" height="1415" alt="KinemagicStudio-CE_3DGS_2025-12-21_02" src="https://github.com/user-attachments/assets/b769ef6e-885c-4b5b-b396-5e6f0707f2bc" />

## その他
<!-- 補足事項・注意点・今後の予定など。（ない場合は「なし」でOK） -->
